### PR TITLE
feat: add dark neon hero design

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,11 +1,13 @@
 /* main.css */
 
 /* Color and Spacing Variables */
+/* Vibrant dark theme inspired by Studio Freight */
 :root {
-    --primary-color: #4a90e2;
-    --secondary-color: #f5f6fa;
-    --accent-color: #34495e;
-    --text-color: #2c3e50;
+    --primary-color: #ff005d;
+    --secondary-color: #111111;
+    --accent-color: #ff005d;
+    --text-color: #f5f5f5;
+    --background-color: #000000;
     --spacing: 2rem;
 }
 
@@ -14,14 +16,13 @@ body {
     font-family: 'Inter', 'Segoe UI', sans-serif;
     line-height: 1.6;
     color: var(--text-color);
-    background-color: var(--secondary-color);
+    background-color: var(--background-color);
     margin: 0;
     padding: 0;
 }
 
 header {
-    background-color: white;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    background-color: transparent;
     padding: 1rem 0;
     text-align: center;
 }
@@ -45,7 +46,7 @@ nav ul li {
 }
 
 nav a {
-    color: var(--accent-color);
+    color: var(--text-color);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.3s ease;
@@ -68,18 +69,20 @@ section {
 footer {
     text-align: center;
     padding: 10px 0;
-    background: #333;
+    background: #111111;
     color: #fff;
 }
 
 /* Tool Container Styling */
 .tool-container {
-    background: white;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 10px;
     padding: 2rem;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
     max-width: 600px;
-    margin: 3rem auto;
+    margin: 2rem auto;
+    backdrop-filter: blur(6px);
 }
 
 .input-group {
@@ -95,7 +98,9 @@ footer {
 .input-group input {
     width: 100%;
     padding: 0.8rem;
-    border: 2px solid #e1e1e1;
+    background: transparent;
+    color: var(--text-color);
+    border: 2px solid rgba(255, 255, 255, 0.2);
     border-radius: 5px;
     font-size: 1.1rem;
     transition: border-color 0.3s ease;
@@ -107,7 +112,8 @@ footer {
 }
 
 .result-group {
-    background: var(--secondary-color);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-color);
     padding: 1rem;
     border-radius: 5px;
     margin: 1.5rem 0;
@@ -115,7 +121,7 @@ footer {
 
 #share-button {
     background-color: var(--primary-color);
-    color: white;
+    color: #fff;
     border: none;
     padding: 1rem 2rem;
     border-radius: 5px;
@@ -126,24 +132,32 @@ footer {
 }
 
 #share-button:hover {
-    background-color: #357abd;
+    background-color: #e60053;
 }
 
 /* Landing Page Specific */
 .hero {
     text-align: center;
-    padding: 4rem 2rem;
+    padding: 0 2rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }
 
 .hero h1 {
-    font-size: 3rem;
+    font-size: 4rem;
     margin-bottom: 1rem;
-    color: var(--accent-color);
+    text-transform: uppercase;
+    background: linear-gradient(90deg, var(--primary-color), #00fff9);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
 }
 
 .hero p {
     font-size: 1.2rem;
-    color: #666;
+    color: #aaaaaa;
     max-width: 600px;
     margin: 0 auto 2rem;
 }

--- a/index.html
+++ b/index.html
@@ -19,17 +19,20 @@
         </nav>
     </header>
     <main>
-        <h1>Username Reverser Tool</h1>
-        <div class="tool-container">
-            <div class="input-group">
-                <label for="username">Your X (Twitter) Username:</label>
-                <input type="text" id="username" placeholder="Enter username (without @)">
+        <section class="hero">
+            <h1>Username Reverser</h1>
+            <p>Enter your X handle and see it flipped in neon style.</p>
+            <div class="tool-container">
+                <div class="input-group">
+                    <label for="username">Your X (Twitter) Username:</label>
+                    <input type="text" id="username" placeholder="Enter username (without @)">
+                </div>
+                <div class="result-group">
+                    <p>Your username backwards is: <span id="reversed-username"></span></p>
+                </div>
+                <button id="share-button">Share on X</button>
             </div>
-            <div class="result-group">
-                <p>Your username backwards is: <span id="reversed-username"></span></p>
-            </div>
-            <button id="share-button">Share on X</button>
-        </div>
+        </section>
     </main>
     <footer>
         <p>&copy; 2023 Static Procrastination Tools. All rights reserved.</p>

--- a/pages/about.html
+++ b/pages/about.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="About me and my website">
-    <link rel="stylesheet" href="../css/main.css">
     <link rel="stylesheet" href="../css/normalize.css">
+    <link rel="stylesheet" href="../css/main.css">
     <title>About</title>
 </head>
 <body>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Contact me for more information.">
-    <link rel="stylesheet" href="../css/main.css">
     <link rel="stylesheet" href="../css/normalize.css">
+    <link rel="stylesheet" href="../css/main.css">
     <title>Contact - Static Website</title>
 </head>
 <body>

--- a/pages/services.html
+++ b/pages/services.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Discover the services I offer to help you reach your goals.">
-    <link rel="stylesheet" href="../css/main.css">
     <link rel="stylesheet" href="../css/normalize.css">
+    <link rel="stylesheet" href="../css/main.css">
     <title>Services - Static Website</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- restyle site with vibrant dark theme and neon accents
- add immersive hero section for the username reverser
- fix CSS load order on subpages for consistent styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fb3717cc8321b78c311ce6499207